### PR TITLE
added create before destroy

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -38,6 +38,10 @@ resource "aws_networkfirewall_firewall_policy" "main" {
     }
   }
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   tags = var.tags
 }
 


### PR DESCRIPTION
to fix problematic issue when
1. you want to destroy existing rule and recreate with a new SID
2. but terraform going to just hang inside a loop because it trying to destroy the rule (but forgot to disassociate it)

so this fix the problem by creating the rule group first
then TG will disassociate old, associate new
then delete old rulegroup